### PR TITLE
Build the Next.js app once in CI and reuse it for parallel jobs.

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v6
@@ -70,7 +70,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: |
-            .next/cacheun
+            .next/cache
           # Generate a new cache whenever packages or source files change.
           key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
           # If source files changed but packages didn't, rebuild from a prior cache.

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -138,10 +138,6 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
 
-      - name: Install Playwright OS dependencies
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx playwright install-deps chromium
-
       - name: Run Playwright tests
         run: npm run test:e2e
 

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -38,6 +38,26 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
+      - name: Cache Next.js compiler cache
+        uses: actions/cache@v6
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-${{ hashFiles('src/**/*.[jt]s', 'src/**/*.[jt]sx', 'next.config.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('package-lock.json') }}-
+
+      - name: Build application
+        run: npm run build
+        env:
+          CI_BUILD_FOR_E2E: "true"
+
+      - name: Upload static export
+        uses: actions/upload-artifact@v7
+        with:
+          name: static-export
+          path: out
+          retention-days: 1
+
   lint:
     runs-on: ubuntu-latest
     needs: build
@@ -48,10 +68,16 @@ jobs:
 
       - &restore-cache-node_modules
         name: Restore node_modules
+        id: restore-node-modules
         uses: actions/cache/restore@v6
         with:
           path: node_modules
           key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+
+      - &install-if-restore-miss
+        name: Install dependencies
+        if: steps.restore-node-modules.outputs.cache-hit != 'true'
+        run: npm ci
 
       - name: Run linter
         run: npm run lint
@@ -67,6 +93,7 @@ jobs:
       - *checkout-code
       - *setup-node
       - *restore-cache-node_modules
+      - *install-if-restore-miss
 
       - name: Run tests with coverage
         run: npm run test:coverage
@@ -79,16 +106,13 @@ jobs:
       - *checkout-code
       - *setup-node
       - *restore-cache-node_modules
+      - *install-if-restore-miss
 
-      - name: Cache next
-        id: cache-next
-        uses: actions/cache@v6
+      - name: Download static export
+        uses: actions/download-artifact@v7
         with:
-          path: .next/cache
-          key: ${{ runner.os }}-nextjs-cache
-
-      - name: Build application
-        run: npm run build
+          name: static-export
+          path: out
 
       - name: Get Playwright version
         id: playwright-version
@@ -114,10 +138,15 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ steps.playwright-cache.outputs.cache-primary-key }}
 
+      - name: Install Playwright OS dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
       - name: Run Playwright tests
         run: npm run test:e2e
 
       - name: Upload Playwright Report
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: playwright-report

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,8 @@
 import type { NextConfig } from "next";
+import {
+  resolveSiteAssetPrefix,
+  resolveSiteBasePath,
+} from "./src/lib/siteBasePath";
 
 const nextConfig: NextConfig = {
   // Use static export for GitHub Pages (main branch)
@@ -7,14 +11,8 @@ const nextConfig: NextConfig = {
   trailingSlash: true,
   // GitHub Pages base path configuration
   // The configure-pages action should inject this, but we'll set it explicitly
-  basePath:
-    process.env.NODE_ENV === "production" && process.env.GITHUB_ACTIONS
-      ? "/foxhole-materials-calculator"
-      : "",
-  assetPrefix:
-    process.env.NODE_ENV === "production" && process.env.GITHUB_ACTIONS
-      ? "/foxhole-materials-calculator/"
-      : "",
+  basePath: resolveSiteBasePath(),
+  assetPrefix: resolveSiteAssetPrefix(),
   images: {
     unoptimized: process.env.VERCEL ? false : true,
     remotePatterns: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,8 @@
 import { defineConfig, devices } from "@playwright/test";
+import {
+  PLAYWRIGHT_BASE_URL,
+  getPlaywrightWebServerCommand,
+} from "./src/lib/playwrightWebServer";
 
 /**
  * Playwright configuration for integration tests.
@@ -19,7 +23,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: "http://localhost:3000",
+    baseURL: PLAYWRIGHT_BASE_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: "on-first-retry",
@@ -35,8 +39,8 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run dev",
-    url: "http://localhost:3000",
+    command: getPlaywrightWebServerCommand(!!process.env.CI),
+    url: PLAYWRIGHT_BASE_URL,
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
   },

--- a/src/__tests__/nextConfig.test.ts
+++ b/src/__tests__/nextConfig.test.ts
@@ -1,0 +1,10 @@
+import nextConfig from "../../next.config";
+
+describe("next.config", () => {
+  it("exports a static site with resolved paths", () => {
+    expect(nextConfig.output).toBe("export");
+    expect(nextConfig.trailingSlash).toBe(true);
+    expect(nextConfig.basePath).toBe("");
+    expect(nextConfig.assetPrefix).toBe("");
+  });
+});

--- a/src/__tests__/playwrightWebServer.test.ts
+++ b/src/__tests__/playwrightWebServer.test.ts
@@ -1,0 +1,20 @@
+import {
+  PLAYWRIGHT_BASE_URL,
+  getPlaywrightWebServerCommand,
+} from "@/lib/playwrightWebServer";
+
+describe("getPlaywrightWebServerCommand", () => {
+  it("serves the static export on CI", () => {
+    expect(getPlaywrightWebServerCommand(true)).toBe(
+      "python3 -m http.server 3000 --directory out --bind 127.0.0.1"
+    );
+  });
+
+  it("uses the Next.js dev server locally", () => {
+    expect(getPlaywrightWebServerCommand(false)).toBe("npm run dev");
+  });
+
+  it("exposes the Playwright base URL", () => {
+    expect(PLAYWRIGHT_BASE_URL).toBe("http://localhost:3000");
+  });
+});

--- a/src/__tests__/siteBasePath.test.ts
+++ b/src/__tests__/siteBasePath.test.ts
@@ -1,0 +1,60 @@
+import {
+  GITHUB_PAGES_BASE_PATH,
+  resolveSiteAssetPrefix,
+  resolveSiteBasePath,
+} from "@/lib/siteBasePath";
+
+describe("resolveSiteBasePath", () => {
+  it("uses NEXT_PUBLIC_BASE_PATH when set", () => {
+    expect(
+      resolveSiteBasePath({
+        NEXT_PUBLIC_BASE_PATH: "/custom",
+        CI_BUILD_FOR_E2E: "true",
+        NODE_ENV: "production",
+        GITHUB_ACTIONS: "true",
+      })
+    ).toBe("/custom");
+  });
+
+  it("skips the GitHub Pages subdirectory for e2e CI builds", () => {
+    expect(
+      resolveSiteBasePath({
+        CI_BUILD_FOR_E2E: "true",
+        NODE_ENV: "production",
+        GITHUB_ACTIONS: "true",
+      })
+    ).toBe("");
+  });
+
+  it("uses the GitHub Pages subdirectory for production Actions builds", () => {
+    expect(
+      resolveSiteBasePath({
+        NODE_ENV: "production",
+        GITHUB_ACTIONS: "true",
+      })
+    ).toBe(GITHUB_PAGES_BASE_PATH);
+  });
+
+  it("is empty for local production and development builds", () => {
+    expect(resolveSiteBasePath({ NODE_ENV: "production" })).toBe("");
+    expect(
+      resolveSiteBasePath({ NODE_ENV: "development", GITHUB_ACTIONS: "true" })
+    ).toBe("");
+    expect(resolveSiteBasePath({})).toBe("");
+  });
+});
+
+describe("resolveSiteAssetPrefix", () => {
+  it("adds a trailing slash when a base path is present", () => {
+    expect(
+      resolveSiteAssetPrefix({
+        NODE_ENV: "production",
+        GITHUB_ACTIONS: "true",
+      })
+    ).toBe(`${GITHUB_PAGES_BASE_PATH}/`);
+  });
+
+  it("is empty when there is no base path", () => {
+    expect(resolveSiteAssetPrefix({ CI_BUILD_FOR_E2E: "true" })).toBe("");
+  });
+});

--- a/src/lib/playwrightWebServer.ts
+++ b/src/lib/playwrightWebServer.ts
@@ -1,0 +1,9 @@
+export const PLAYWRIGHT_BASE_URL = "http://localhost:3000";
+
+export function getPlaywrightWebServerCommand(isCi: boolean): string {
+  if (isCi) {
+    return "python3 -m http.server 3000 --directory out --bind 127.0.0.1";
+  }
+
+  return "npm run dev";
+}

--- a/src/lib/siteBasePath.ts
+++ b/src/lib/siteBasePath.ts
@@ -1,0 +1,30 @@
+export type SitePathEnv = {
+  NEXT_PUBLIC_BASE_PATH?: string;
+  CI_BUILD_FOR_E2E?: string;
+  NODE_ENV?: string;
+  GITHUB_ACTIONS?: string;
+};
+
+export const GITHUB_PAGES_BASE_PATH = "/foxhole-materials-calculator";
+
+export function resolveSiteBasePath(env: SitePathEnv = process.env): string {
+  if (env.NEXT_PUBLIC_BASE_PATH) {
+    return env.NEXT_PUBLIC_BASE_PATH;
+  }
+
+  // Lint-and-test builds the static export for Playwright at `/`.
+  if (env.CI_BUILD_FOR_E2E === "true") {
+    return "";
+  }
+
+  if (env.NODE_ENV === "production" && env.GITHUB_ACTIONS === "true") {
+    return GITHUB_PAGES_BASE_PATH;
+  }
+
+  return "";
+}
+
+export function resolveSiteAssetPrefix(env: SitePathEnv = process.env): string {
+  const basePath = resolveSiteBasePath(env);
+  return basePath ? `${basePath}/` : "";
+}


### PR DESCRIPTION
Share the static export via artifacts so e2e does not rebuild, and fix the Pages compiler-cache path typo.